### PR TITLE
Update map_test.c - fixed memory leak

### DIFF
--- a/map_tests.c
+++ b/map_tests.c
@@ -307,7 +307,9 @@ bool testMapForEach() {
     MAP_FOREACH(key,map_2){
         ASSERT_TEST(mapGet(map,key)!=NULL);
     }
-
+    
+    mapDestroy(map);
+    mapDestroy(map_2);
     return true;
 }
 


### PR DESCRIPTION
Function testMapForEach (line 270), added mapDestroy() for used local maps.